### PR TITLE
Bump Dash SDK to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "commander": "^12.1.0",
-        "dash": "^4.7.1",
+        "dash": "4.8.0",
         "dotenv": "^16.4.5"
     },
     "devDependencies": {


### PR DESCRIPTION
# Issue

Currently Dash Platform network operate on protocol version 1.8.0, so its better to use latest stable SDK

# Things done

* Upgraded `dash` package to 4.8.0 and set a strict match